### PR TITLE
[BugFix] real clip the mirror in layout level not draw level.

### DIFF
--- a/app/src/main/java/com/jetpack/mirroreffectwithcompose/MainActivity.kt
+++ b/app/src/main/java/com/jetpack/mirroreffectwithcompose/MainActivity.kt
@@ -81,7 +81,7 @@ fun Mirror(
     Column {
         content()
         MirrorLayout(
-            fraction = .6f
+            fraction = .5f
         ) {
             content()
         }
@@ -100,7 +100,7 @@ fun MirrorLayout(
                 rotationZ = 180f
             }
             .drawWithContent {
-                val colors = listOf(lerp(Color.Transparent, Color.White, fraction), Color.White)
+                val colors = listOf(lerp(Color.White, Color.Transparent, fraction), Color.White)
                 drawContent()
                 drawRect(
                     brush = Brush.verticalGradient(colors),


### PR DESCRIPTION
This implementation has the same result, but the hidden rest of the 'mirror' will not occupy the space.That means we clip in layout level instead of draw level.